### PR TITLE
Create hyperslab read test and changes to make functional

### DIFF
--- a/Source/Dataset.swift
+++ b/Source/Dataset.swift
@@ -33,11 +33,16 @@ public class Dataset : Object {
 
     // MARK: Reading/Writing data
 
-    public func readDouble(data: UnsafeMutablePointer<Double>) -> Bool {
-        let status = H5Dread(id, NativeType.Double.rawValue, 0, 0, 0, data)
-        return status >= 0
+    public func readDouble(data: UnsafeMutablePointer<Double>, memspace_id: Int32 = 0, dataspace_id: Int32 = 0) -> Bool {
+      let status = H5Dread(id, NativeType.Double.rawValue, memspace_id, dataspace_id, 0, data)
+      return status >= 0
     }
-    
+
+//    public func readDouble(data: UnsafeMutablePointer<Double>) -> Bool {
+//        let status = H5Dread(id, NativeType.Double.rawValue, 0, 0, 0, data)
+//        return status >= 0
+//    }
+  
     public func readDouble() -> [Double] {
         var result = [Double](count: Int(space.size), repeatedValue: 0.0)
         readDouble(&result)

--- a/Source/Dataset.swift
+++ b/Source/Dataset.swift
@@ -37,11 +37,6 @@ public class Dataset : Object {
       let status = H5Dread(id, NativeType.Double.rawValue, memspace_id, dataspace_id, 0, data)
       return status >= 0
     }
-
-//    public func readDouble(data: UnsafeMutablePointer<Double>) -> Bool {
-//        let status = H5Dread(id, NativeType.Double.rawValue, 0, 0, 0, data)
-//        return status >= 0
-//    }
   
     public func readDouble() -> [Double] {
         var result = [Double](count: Int(space.size), repeatedValue: 0.0)


### PR DESCRIPTION
Successfully reads a dataset subset to memory.

I had to tweak <code>dataset.readDouble()</code> to get to the C API to set memspace and dataspace ids. There may also be some rethink with <code>Dataset.space</code> as a computed property as I'm not getting the correct id if I reference <code>space.id</code> from within <code>readDouble</code>