### PR TITLE
Implement subscript reads

### DIFF
--- a/HDF5Kit.xcodeproj/project.pbxproj
+++ b/HDF5Kit.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		2241F9461BFE675900014748 /* HyperslabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2241F9451BFE675900014748 /* HyperslabTests.swift */; };
 		2241F9471BFE675900014748 /* HyperslabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2241F9451BFE675900014748 /* HyperslabTests.swift */; };
+		22B02AAF1BFE80A10054F2BF /* IndexingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B02AAE1BFE80A10054F2BF /* IndexingTests.swift */; };
+		22B02AB01BFE80A10054F2BF /* IndexingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B02AAE1BFE80A10054F2BF /* IndexingTests.swift */; };
+		22B02AB21BFE832B0054F2BF /* H5Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B02AB11BFE832B0054F2BF /* H5Index.swift */; };
+		22B02AB31BFE832B0054F2BF /* H5Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B02AB11BFE832B0054F2BF /* H5Index.swift */; };
 		616B83AA1BDC61A600B28545 /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B83A91BDC61A600B28545 /* Group.swift */; };
 		616B83AB1BDC61A600B28545 /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B83A91BDC61A600B28545 /* Group.swift */; };
 		616B83AD1BDD493200B28545 /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B83AC1BDD493200B28545 /* Object.swift */; };
@@ -723,6 +727,8 @@
 
 /* Begin PBXFileReference section */
 		2241F9451BFE675900014748 /* HyperslabTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HyperslabTests.swift; sourceTree = "<group>"; };
+		22B02AAE1BFE80A10054F2BF /* IndexingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexingTests.swift; sourceTree = "<group>"; };
+		22B02AB11BFE832B0054F2BF /* H5Index.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = H5Index.swift; sourceTree = "<group>"; };
 		616B83A91BDC61A600B28545 /* Group.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Group.swift; sourceTree = "<group>"; };
 		616B83AC1BDD493200B28545 /* Object.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Object.swift; sourceTree = "<group>"; };
 		616B83AF1BDD5A8500B28545 /* GroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupTests.swift; sourceTree = "<group>"; };
@@ -1176,6 +1182,7 @@
 				61B317961BBDE74400F63C45 /* Dataspace.swift */,
 				61B317981BBDEAD700F63C45 /* Datatype.swift */,
 				61B3179A1BBDF1C900F63C45 /* Dataset.swift */,
+				22B02AB11BFE832B0054F2BF /* H5Index.swift */,
 				616B83A91BDC61A600B28545 /* Group.swift */,
 				61B3179C1BBE21CE00F63C45 /* NativeType.swift */,
 				616B83AC1BDD493200B28545 /* Object.swift */,
@@ -1187,6 +1194,7 @@
 		61B314AB1BBDBA3200F63C45 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				22B02AAE1BFE80A10054F2BF /* IndexingTests.swift */,
 				616B83B21BDD5B9700B28545 /* Helpers.swift */,
 				617187831BFCF64200FB5D5F /* DataspaceTests.swift */,
 				61B314AC1BBDBA3200F63C45 /* FileTests.swift */,
@@ -2085,6 +2093,7 @@
 				6185A95B1BD339FD00CD5FC5 /* H5Pdcpl.c in Sources */,
 				6185A8DA1BD339FD00CD5FC5 /* H5E.c in Sources */,
 				6185A9431BD339FD00CD5FC5 /* H5Odbg.c in Sources */,
+				22B02AB31BFE832B0054F2BF /* H5Index.swift in Sources */,
 				6185A9371BD339FD00CD5FC5 /* H5MPtest.c in Sources */,
 				6185A92D1BD339FD00CD5FC5 /* H5Itest.c in Sources */,
 				6185A9961BD339FD00CD5FC5 /* H5TS.c in Sources */,
@@ -2175,6 +2184,7 @@
 				616B83B41BDD5B9700B28545 /* Helpers.swift in Sources */,
 				616B83B11BDD5A8500B28545 /* GroupTests.swift in Sources */,
 				2241F9471BFE675900014748 /* HyperslabTests.swift in Sources */,
+				22B02AB01BFE80A10054F2BF /* IndexingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2353,6 +2363,7 @@
 				61B3168A1BBDBA8E00F63C45 /* H5Fint.c in Sources */,
 				61B317201BBDBA8E00F63C45 /* H5Pfcpl.c in Sources */,
 				61B316C11BBDBA8E00F63C45 /* H5HFiter.c in Sources */,
+				22B02AB21BFE832B0054F2BF /* H5Index.swift in Sources */,
 				61B316D31BBDBA8E00F63C45 /* H5HLcache.c in Sources */,
 				61B3176D1BBDBA8E00F63C45 /* H5TS.c in Sources */,
 				61B3175F1BBDBA8E00F63C45 /* H5Tfixed.c in Sources */,
@@ -2443,6 +2454,7 @@
 				616B83B31BDD5B9700B28545 /* Helpers.swift in Sources */,
 				616B83B01BDD5A8500B28545 /* GroupTests.swift in Sources */,
 				2241F9461BFE675900014748 /* HyperslabTests.swift in Sources */,
+				22B02AAF1BFE80A10054F2BF /* IndexingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HDF5Kit.xcodeproj/xcshareddata/xcschemes/HDF5Kit-OSX.xcscheme
+++ b/HDF5Kit.xcodeproj/xcshareddata/xcschemes/HDF5Kit-OSX.xcscheme
@@ -51,6 +51,20 @@
                BlueprintName = "HDF5KitTests-OSX"
                ReferencedContainer = "container:HDF5Kit.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "DataspaceTests">
+               </Test>
+               <Test
+                  Identifier = "FileTests">
+               </Test>
+               <Test
+                  Identifier = "GroupTests">
+               </Test>
+               <Test
+                  Identifier = "HyperslabTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/HDF5Kit.xcodeproj/xcshareddata/xcschemes/HDF5Kit-OSX.xcscheme
+++ b/HDF5Kit.xcodeproj/xcshareddata/xcschemes/HDF5Kit-OSX.xcscheme
@@ -51,20 +51,6 @@
                BlueprintName = "HDF5KitTests-OSX"
                ReferencedContainer = "container:HDF5Kit.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "DataspaceTests">
-               </Test>
-               <Test
-                  Identifier = "FileTests">
-               </Test>
-               <Test
-                  Identifier = "GroupTests">
-               </Test>
-               <Test
-                  Identifier = "HyperslabTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/Source/Dataset.swift
+++ b/Source/Dataset.swift
@@ -51,22 +51,19 @@ public class Dataset : Object {
         let dataspace = space
         var dimsOut = space.dims
         
-        if !sliceDims.isEmpty { // request for all data so use existing dataspace dims
+        if !sliceDims.isEmpty {
 
             var slabOffset: [Int] = []
             for (i, dim) in sliceDims.enumerate() {
                 
-                slabOffset.append(dim.slice.startIndex < 0 ? 0 : dim.slice.startIndex)
-                if dim.slice.endIndex < MAX {
-                    dimsOut[i] = dim.slice.endIndex - (dim.slice.startIndex < 0 ? 0 : dim.slice.startIndex)
+                slabOffset.append(dim.slice.startIndex)
+                if dim.slice.endIndex < Int.max-1 {
+                    dimsOut[i] = dim.slice.endIndex - (dim.slice.startIndex)
                 } else {
-                    // max
                     dimsOut[i] -= dim.slice.startIndex
                 }
                 
             }
-            print("slabOffset = \(slabOffset)")
-            print("dimsOut = \(dimsOut)")
             // define hyperslab in dataset
             dataspace.select(start: slabOffset, stride: nil, count: dimsOut, block: nil)
         }

--- a/Source/Dataset.swift
+++ b/Source/Dataset.swift
@@ -48,26 +48,27 @@ public class Dataset : Object {
 
     public subscript(sliceDims: H5Index...) -> [Double] {
 
-        var dataspace: Dataspace
-
         var dimsOut: [Int] = []
+        let dataspace = space
+        dimsOut = space.dims
         
-        if sliceDims.isEmpty { // request for all data so use dataspace dims
-            dataspace = space
-            dimsOut = space.dims
-        } else {
+        if !sliceDims.isEmpty { // request for all data so use existing dataspace dims
+
             var slabOffset: [Int] = []
-            for dim in sliceDims {
-                // get slice attributes
+            for (i, dim) in sliceDims.enumerate() {
 
                 // define hyperslab in dataset
-                slabOffset.append(dim.slice.startIndex)
-                dimsOut.append(dim.slice.endIndex)
+                slabOffset.append(dim.slice.startIndex < 0 ? 0 : dim.slice.startIndex)
+                if dim.slice.endIndex < MAX {
+                    dimsOut[i] = dim.slice.endIndex - dim.slice.startIndex
+                } else {
+                    dimsOut[i] -= dim.slice.startIndex
+                }
                 
             }
             print("slabOffset = \(slabOffset)")
             print("dimsOut = \(dimsOut)")
-            dataspace = space
+            
             dataspace.select(start: slabOffset, stride: nil, count: dimsOut, block: nil)
         }
         // define memspace

--- a/Source/Dataset.swift
+++ b/Source/Dataset.swift
@@ -62,7 +62,6 @@ public class Dataset : Object {
                 } else {
                     dimsOut[i] -= dim.slice.startIndex
                 }
-                
             }
             // define hyperslab in dataset
             dataspace.select(start: slabOffset, stride: nil, count: dimsOut, block: nil)

--- a/Source/Dataset.swift
+++ b/Source/Dataset.swift
@@ -48,27 +48,26 @@ public class Dataset : Object {
 
     public subscript(sliceDims: H5Index...) -> [Double] {
 
-        var dimsOut: [Int] = []
         let dataspace = space
-        dimsOut = space.dims
+        var dimsOut = space.dims
         
         if !sliceDims.isEmpty { // request for all data so use existing dataspace dims
 
             var slabOffset: [Int] = []
             for (i, dim) in sliceDims.enumerate() {
-
-                // define hyperslab in dataset
+                
                 slabOffset.append(dim.slice.startIndex < 0 ? 0 : dim.slice.startIndex)
                 if dim.slice.endIndex < MAX {
-                    dimsOut[i] = dim.slice.endIndex - dim.slice.startIndex
+                    dimsOut[i] = dim.slice.endIndex - (dim.slice.startIndex < 0 ? 0 : dim.slice.startIndex)
                 } else {
+                    // max
                     dimsOut[i] -= dim.slice.startIndex
                 }
                 
             }
             print("slabOffset = \(slabOffset)")
             print("dimsOut = \(dimsOut)")
-            
+            // define hyperslab in dataset
             dataspace.select(start: slabOffset, stride: nil, count: dimsOut, block: nil)
         }
         // define memspace

--- a/Source/H5Index.swift
+++ b/Source/H5Index.swift
@@ -1,0 +1,38 @@
+//
+// Created by Tim Burgess on 17/11/2015.
+//
+// This file is part of HDF5Kit. The full HDF5Kit copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+postfix operator .. {}
+
+prefix operator .. {}
+
+postfix func .. (lhs: Int) -> Range<Int> {
+  return lhs...Int.max-1
+}
+
+prefix func .. (rhs: Int) -> Range<Int> {
+  return Int.min...rhs
+}
+
+public protocol H5Index {
+  var slice: Range<Int> { get }
+}
+
+extension Int: H5Index {
+  public var slice: Range<Int> {
+    get {
+      return Range<Int>(start: self, end: self+1)
+    }
+  }
+}
+extension Range: H5Index {
+  public var slice: Range<Int> {
+    get {
+      return Range<Int>(start: self.startIndex as! Int, end: self.endIndex as! Int)
+    }
+  }
+}
+

--- a/Source/H5Index.swift
+++ b/Source/H5Index.swift
@@ -9,30 +9,33 @@ postfix operator .. {}
 
 prefix operator .. {}
 
-postfix func .. (lhs: Int) -> Range<Int> {
-  return lhs...Int.max-1
+let MAX = Int.max-1
+let MIN = Int.min
+
+public postfix func .. (lhs: Int) -> Range<Int> {
+    return lhs...MAX
 }
 
-prefix func .. (rhs: Int) -> Range<Int> {
-  return Int.min...rhs
+public prefix func .. (rhs: Int) -> Range<Int> {
+    return Int.min...rhs
 }
 
 public protocol H5Index {
-  var slice: Range<Int> { get }
+      var slice: Range<Int> { get }
 }
 
 extension Int: H5Index {
-  public var slice: Range<Int> {
-    get {
-      return Range<Int>(start: self, end: self+1)
+    public var slice: Range<Int> {
+        get {
+            return Range<Int>(start: self, end: self+1)
+        }
     }
-  }
 }
 extension Range: H5Index {
-  public var slice: Range<Int> {
-    get {
-      return Range<Int>(start: self.startIndex as! Int, end: self.endIndex as! Int)
+    public var slice: Range<Int> {
+        get {
+          return Range<Int>(start: self.startIndex as! Int, end: self.endIndex as! Int)
+        }
     }
-  }
 }
 

--- a/Source/H5Index.swift
+++ b/Source/H5Index.swift
@@ -9,15 +9,12 @@ postfix operator .. {}
 
 prefix operator .. {}
 
-let MAX = Int.max-1
-let MIN = Int.min
-
 public postfix func .. (lhs: Int) -> Range<Int> {
-    return lhs...MAX
+    return lhs...Int.max-1
 }
 
 public prefix func .. (rhs: Int) -> Range<Int> {
-    return Int.min...rhs
+    return 0...rhs
 }
 
 public protocol H5Index {

--- a/Tests/IndexingTests.swift
+++ b/Tests/IndexingTests.swift
@@ -32,23 +32,9 @@ class IndexingTests: XCTestCase {
         let data = (0..<size).map { Double($0) }
         
         let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
-        let result = dataset[0..,0...1] // first two columns of all rows
+        let result = dataset[0..,0...1] // all rows and first two columns
         
         XCTAssertEqual(result, [0.0, 1.0, 3.0, 4.0, 6.0, 7.0])
-    }
-
-    func testSliceLastTwoRows() {
-        
-        let file = createFile(tempFilePath())
-        
-        let createDims = [3, 3]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
-        let result = dataset[1..,0..] // rows from second row with all columns
-        
-        XCTAssertEqual(result, [3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
     }
 
     func testSliceFirstTwoRows() {
@@ -60,12 +46,12 @@ class IndexingTests: XCTestCase {
         let data = (0..<size).map { Double($0) }
         
         let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
-        let result = dataset[0...1,0..] // first two rows with all columns
+        let result = dataset[..1,0..] // first two rows and all columns
         
         XCTAssertEqual(result, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
     }
-    
-    func testSlice2x2Read() {
+
+    func testSliceLastTwoRows() {
         
         let file = createFile(tempFilePath())
         
@@ -74,22 +60,79 @@ class IndexingTests: XCTestCase {
         let data = (0..<size).map { Double($0) }
         
         let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
-        let result = dataset[0...1,0...1]
+        let result = dataset[1..,0..] // last two rows and all columns
         
-        XCTAssertEqual(result, [0.0, 1.0, 3.0, 4.0])
+        XCTAssertEqual(result, [3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
     }
 
-//    func testSliceAllRead2() {
-//        
-//        let file = createFile(tempFilePath())
-//        
-//        let createDims = [3, 3]
-//        let size = createDims.reduce(1, combine: *)
-//        let data = (0..<size).map { Double($0) }
-//        
-//        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
-//        let result = dataset[0..,0..]
-//        
-//        XCTAssertEqual(result, [0.0, 1.0, 3.0, 4.0])
-//    }
+    func testSliceLastTwoColumns() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let result = dataset[0..,1..] // all rows and last two columns
+        
+        XCTAssertEqual(result, [1.0, 2.0, 4.0, 5.0, 7.0, 8.0])
+    }
+    
+    func testSliceLastTwoColumnsOfLastTwoRows() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let result = dataset[1..,1..] // last two columns of last two rows
+        
+        XCTAssertEqual(result, [4.0, 5.0, 7.0, 8.0])
+    }
+
+    func testSliceMiddleValue() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let result = dataset[1,1]
+        
+        XCTAssertEqual(result, [4.0])
+    }
+    
+    func testSliceMiddleRow() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let result = dataset[1,0..] // middle row, all columns
+
+        XCTAssertEqual(result, [3.0, 4.0, 5.0])
+    }
+
+    func testSliceLastColumn() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let result = dataset[0..,2] // middle row, all columns
+        
+        XCTAssertEqual(result, [2.0, 5.0, 8.0])
+    }
+    
 }

--- a/Tests/IndexingTests.swift
+++ b/Tests/IndexingTests.swift
@@ -1,0 +1,39 @@
+// Created by Tim Burgess on 20/11/2015.
+//
+// This file is part of HDF5Kit. The full HDF5Kit copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+import XCTest
+import HDF5Kit
+
+class IndexingTests: XCTestCase {
+    let datasetName = "MyData"
+    
+    func testAllRead() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [4, 4]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+
+        XCTAssertEqual(dataset[], dataset.readDouble())
+    }
+    
+    func testSlice2x2Read() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let result = dataset[0...1,0...1]
+        
+        XCTAssertEqual(result, [0.0, 1.0, 3.0, 4.0])
+    }
+}

--- a/Tests/IndexingTests.swift
+++ b/Tests/IndexingTests.swift
@@ -9,71 +9,45 @@ import HDF5Kit
 
 class IndexingTests: XCTestCase {
     let datasetName = "MyData"
+
+    func createDataset() -> Dataset {
+        let file = createFile(tempFilePath())
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        return file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+    }
     
     func testAllRead() {
         
-        let file = createFile(tempFilePath())
-        
-        let createDims = [4, 4]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
-
+        let dataset = createDataset()
         XCTAssertEqual(dataset[], dataset.readDouble())
     }
     
     func testSliceFirstTwoColumns() {
         
-        let file = createFile(tempFilePath())
-        
-        let createDims = [3, 3]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let dataset = createDataset()
         let result = dataset[0..,0...1] // all rows and first two columns
-        
         XCTAssertEqual(result, [0.0, 1.0, 3.0, 4.0, 6.0, 7.0])
     }
 
     func testSliceFirstTwoRows() {
         
-        let file = createFile(tempFilePath())
-        
-        let createDims = [3, 3]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let dataset = createDataset()
         let result = dataset[..1,0..] // first two rows and all columns
-        
         XCTAssertEqual(result, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
     }
 
     func testSliceLastTwoRows() {
         
-        let file = createFile(tempFilePath())
-        
-        let createDims = [3, 3]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let dataset = createDataset()
         let result = dataset[1..,0..] // last two rows and all columns
-        
         XCTAssertEqual(result, [3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
     }
 
     func testSliceLastTwoColumns() {
         
-        let file = createFile(tempFilePath())
-        
-        let createDims = [3, 3]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let dataset = createDataset()
         let result = dataset[0..,1..] // all rows and last two columns
         
         XCTAssertEqual(result, [1.0, 2.0, 4.0, 5.0, 7.0, 8.0])
@@ -81,57 +55,29 @@ class IndexingTests: XCTestCase {
     
     func testSliceLastTwoColumnsOfLastTwoRows() {
         
-        let file = createFile(tempFilePath())
-        
-        let createDims = [3, 3]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let dataset = createDataset()
         let result = dataset[1..,1..] // last two columns of last two rows
-        
         XCTAssertEqual(result, [4.0, 5.0, 7.0, 8.0])
     }
 
     func testSliceMiddleValue() {
         
-        let file = createFile(tempFilePath())
-        
-        let createDims = [3, 3]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let dataset = createDataset()
         let result = dataset[1,1]
-        
         XCTAssertEqual(result, [4.0])
     }
     
     func testSliceMiddleRow() {
         
-        let file = createFile(tempFilePath())
-        
-        let createDims = [3, 3]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let dataset = createDataset()
         let result = dataset[1,0..] // middle row, all columns
-
         XCTAssertEqual(result, [3.0, 4.0, 5.0])
     }
 
     func testSliceLastColumn() {
         
-        let file = createFile(tempFilePath())
-        
-        let createDims = [3, 3]
-        let size = createDims.reduce(1, combine: *)
-        let data = (0..<size).map { Double($0) }
-        
-        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let dataset = createDataset()
         let result = dataset[0..,2] // middle row, all columns
-        
         XCTAssertEqual(result, [2.0, 5.0, 8.0])
     }
     

--- a/Tests/IndexingTests.swift
+++ b/Tests/IndexingTests.swift
@@ -23,6 +23,48 @@ class IndexingTests: XCTestCase {
         XCTAssertEqual(dataset[], dataset.readDouble())
     }
     
+    func testSliceFirstTwoColumns() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let result = dataset[0..,0...1] // first two columns of all rows
+        
+        XCTAssertEqual(result, [0.0, 1.0, 3.0, 4.0, 6.0, 7.0])
+    }
+
+    func testSliceLastTwoRows() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let result = dataset[1..,0..] // rows from second row with all columns
+        
+        XCTAssertEqual(result, [3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+    }
+
+    func testSliceFirstTwoRows() {
+        
+        let file = createFile(tempFilePath())
+        
+        let createDims = [3, 3]
+        let size = createDims.reduce(1, combine: *)
+        let data = (0..<size).map { Double($0) }
+        
+        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+        let result = dataset[0...1,0..] // first two rows with all columns
+        
+        XCTAssertEqual(result, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+    }
+    
     func testSlice2x2Read() {
         
         let file = createFile(tempFilePath())
@@ -36,4 +78,18 @@ class IndexingTests: XCTestCase {
         
         XCTAssertEqual(result, [0.0, 1.0, 3.0, 4.0])
     }
+
+//    func testSliceAllRead2() {
+//        
+//        let file = createFile(tempFilePath())
+//        
+//        let createDims = [3, 3]
+//        let size = createDims.reduce(1, combine: *)
+//        let data = (0..<size).map { Double($0) }
+//        
+//        let dataset = file.createAndWriteDataset(datasetName, dims: createDims, data: data)
+//        let result = dataset[0..,0..]
+//        
+//        XCTAssertEqual(result, [0.0, 1.0, 3.0, 4.0])
+//    }
 }


### PR DESCRIPTION
This enables subscript slicing with a slice defined by either an Int, a Range or a `subrange` such as `..2`. Supplied tests provide examples of a variety of slice definitions.