### PR TITLE
Allow carthage to build HDF5Kit

### DIFF
--- a/Tests/FileTests.swift
+++ b/Tests/FileTests.swift
@@ -5,7 +5,7 @@
 // file LICENSE at the root of the source code distribution tree.
 
 import XCTest
-@testable import HDF5Kit
+import HDF5Kit
 
 class FileTests: XCTestCase {
     let width = 100


### PR DESCRIPTION
With @testable removed, Carthage can successfully build both OSX and iOS.