### PR TITLE
return Any instead of [AnyObject]

### DIFF
--- a/Sources/Dataset.swift
+++ b/Sources/Dataset.swift
@@ -55,7 +55,7 @@ public class Dataset<Element> : Object {
         return chunkSize
     }
 
-    public subscript(slices: HyperslabIndexType...) -> [AnyObject] {
+    public subscript(slices: HyperslabIndexType...) -> Any {
         get {
             let filespace = space
             filespace.select(slices)
@@ -72,7 +72,7 @@ public class Dataset<Element> : Object {
     /// Read data using an optional memory Dataspace and an optional file Dataspace
     ///
     /// - precondition: The `selectionSize` of the memory Dataspace is the same as for the file Dataspace
-    public func read(memSpace memSpace: Dataspace? = nil, fileSpace: Dataspace? = nil) -> [AnyObject] {
+    public func read(memSpace memSpace: Dataspace? = nil, fileSpace: Dataspace? = nil) -> Any {
         let size: Int
         if let memspace = memSpace {
             size = memspace.selectionSize


### PR DESCRIPTION
Having done some more investigation, it seems as though importing Foundation (on OS X at least), does some behind the scenes casting to NSNumber to allow a return as AnyObject. However on Linux, NSNumber in the new <i>Swift from the ground-up</i> Foundation is not implemented (certainly not the Double support) and is not available.

Although not ideal, returning <code>Any</code> allows the code to build on Linux and allows <code>... as! [Double]</code> to work from the client code. If the wrong cast is used, i.e. <code>[Float]</code>, the runtime error is pretty descriptive to the enduser - `Could not cast value of type 'Swift.Array<Swift.Double>' (0x100597028) to 'Swift.Array<Swift.Float>' (0x100597080)` 

And fyi, `Source` and `Sources` are both valid directories for the new package manager.