### PR TITLE
fix build with swift package manager

### DIFF
--- a/Source/StringAttribute.swift
+++ b/Source/StringAttribute.swift
@@ -6,6 +6,7 @@
 
  #if SWIFT_PACKAGE
     import CHDF5
+    import Foundation
  #endif
 
 open class StringAttribute: Attribute {


### PR DESCRIPTION
 `import Foundation` in StringAttribute.swift is required when building with `swift build`, otherwise it fails with

```
HDF5Kit/Source/StringAttribute.swift:70:26: error: value of type 'String' has no member 'lengthOfBytes'
                index += string.lengthOfBytes(using: .ascii)
                         ^~~~~~ ~~~~~~~~~~~~~
```


tested on MacOS with `Apple Swift version 4.2.1 (swiftlang-1000.11.42 clang-1000.11.45.1)
Target: x86_64-apple-darwin18.2.0`